### PR TITLE
Refactor to a standard-layout plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# https://editorconfig.org
+root=true
+[*]
+end_of_line = LF
+[*.vim]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 *.pm
 *.xcf
+
+# Backup and temporary files
+*.swp
+*~
+~*
+*.bak
+*.tdy
+*.old

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Hash-Tidy
----------
-Fight entropy and disorder! Tidy your Perl hashes in vim.
+=========
+Fight entropy and disorder! Tidy your Perl/Raku hashes in vim.
 
 It can sort keys by length:
 
@@ -15,15 +15,39 @@ Or do both:
 ![](hash-tidy-sort-align.gif)
 
 Installation
-------------
+============
 This assumes you have Vim's builtin [filetype plugin option](http://vimdoc.sourceforge.net/htmldoc/filetype.html#:filetype-plugin-on)
-enabled. (e.g. something like `filetype plugin on` in your `.vimrc`).
+enabled. (e.g., something like `filetype plugin on` in your `.vimrc`).
 
-To install as a plugin, save `plugin/hash-tidy.vim` to
-`~/.vim/plugin/hash-tidy.vim`.
+You can install this the same way you install any other Vim plugin: your
+choice of raw unpacking, Pathogen, Vim-8 native, vim-plug, vundle, and
+many other options.  Some of the ways are described in
+[this gist](https://gist.github.com/manasthakur/ab4cf8d32a28ea38271ac0d07373bb53).
+A walkthrough of Vim-8 native package installation is given in
+[this blog post](https://shapeshed.com/vim-packages/).
 
-Next map shortcuts to run the routines. As this plugin works on Perl hashes,
-you might put this code in `~/.vim/ftplugin/perl.vim`:
+Quick-and-dirty installation
+----------------------------
+
+In case you don't want to read the above links :) , you can:
+
+1. Clone this repository into a location of your choice, e.g., `~/src/Hash-Tidy`.
+
+2. Add this line to your `~/.vim/vimrc` file:
+
+       set runtimepath+=~/src/Hash-Tidy
+
+   (or whatever path you used).
+
+3. Restart Vim.
+
+Mapping Shortcuts
+-----------------
+
+After installing Hash-Tidy by whatever choice you prefer, you can
+map shortcuts to run the routines. As this plugin works on Perl/Raku hashes,
+you might put this code in `~/.vim/ftplugin/perl.vim` and
+`~/.vim/ftplugin/perl6.vim` (for Raku):
 
 ```
 vnoremap <buffer> <localleader>a :HashTidyAlignRange<cr>
@@ -32,13 +56,12 @@ vnoremap <buffer> <localleader>sa :HashTidySortAlignRange<cr>
 ```
 
 In visual mode these map the shortcuts `leader` + s to sort, `leader` + a
-to align and `leader` + sa to sort and align.
-
-Alternatively append all of this code to `~/.vim/ftplugin/perl.vim`.
+to align and `leader` + sa to sort and align.  (The default `leader` is a
+backslash.)
 
 License
--------
-Copyright 2020 David Farrell
+=======
+Copyright 2020 David Farrell and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/autoload/dnmfarrell/hashtidy.vim
+++ b/autoload/dnmfarrell/hashtidy.vim
@@ -1,5 +1,5 @@
-function! HashTidyAlignKeyPairs(startline, endline)
-  let maxCol = HashTidyFindMaxSeparatorCol(a:startline, a:endline)
+function! dnmfarrell#hashtidy#HashTidyAlignKeyPairs(startline, endline)
+  let maxCol = s:HashTidyFindMaxSeparatorCol(a:startline, a:endline)
   exec 'normal! ' . a:startline . 'G1|w'
   norm 1|f=
   let whitespace = repeat(' ', maxCol - col('.'))
@@ -12,7 +12,7 @@ function! HashTidyAlignKeyPairs(startline, endline)
   exec 'normal! ' . a:startline . 'G1|w'
 endfunction
 
-function! HashTidyFindMaxSeparatorCol(startline, endline)
+function! s:HashTidyFindMaxSeparatorCol(startline, endline)
   exec 'normal! ' . a:startline . 'G1|w'
   norm 1|f=
   let maxCol = col('.')
@@ -25,18 +25,18 @@ function! HashTidyFindMaxSeparatorCol(startline, endline)
   return maxCol
 endfunction
 
-function! HashTidySortKeyPairs(startline, endline)
-  call HashTidyInsertFirstWordLength()
+function! dnmfarrell#hashtidy#HashTidySortKeyPairs(startline, endline)
+  call s:HashTidyInsertFirstWordLength()
   while line('.') < a:endline " handle end of file
     norm j
-    call HashTidyInsertFirstWordLength()
+    call s:HashTidyInsertFirstWordLength()
   endwhile
   exec ':' . a:startline . ',' . a:endline . 'sort!n'
   exec ':' . a:startline . ',' . a:endline . 's/^\d\+//e'
   exec 'normal! ' . a:startline . 'G'
 endfunction
 
-function! HashTidyInsertFirstWordLength()
+function! s:HashTidyInsertFirstWordLength()
   norm 1|w
   let startCol = col('.')
   let firstChar = getline('.')[startCol-1]
@@ -50,11 +50,11 @@ function! HashTidyInsertFirstWordLength()
   exec 'normal! i' . wordlen
 endfunction
 
-function! HashTidySortAlignKeyPairs () range
-  call HashTidySortKeyPairs(a:firstline, a:lastline)
-  call HashTidyAlignKeyPairs(a:firstline, a:lastline)
+function! dnmfarrell#hashtidy#HashTidySortAlignKeyPairs () range
+  call dnmfarrell#hashtidy#HashTidySortKeyPairs(a:firstline, a:lastline)
+  call dnmfarrell#hashtidy#HashTidyAlignKeyPairs(a:firstline, a:lastline)
 endfunction
 
-command! -range HashTidySortRange call HashTidySortKeyPairs(<line1>,<line2>)
-command! -range HashTidyAlignRange call HashTidyAlignKeyPairs(<line1>,<line2>)
-command! -range HashTidySortAlignRange <line1>,<line2>call HashTidySortAlignKeyPairs()
+command! -range HashTidySortRange call dnmfarrell#hashtidy#HashTidySortKeyPairs(<line1>,<line2>)
+command! -range HashTidyAlignRange call dnmfarrell#hashtidy#HashTidyAlignKeyPairs(<line1>,<line2>)
+command! -range HashTidySortAlignRange <line1>,<line2>call dnmfarrell#hashtidy#HashTidySortAlignKeyPairs()

--- a/autoload/dnmfarrell/hashtidy.vim
+++ b/autoload/dnmfarrell/hashtidy.vim
@@ -54,7 +54,3 @@ function! dnmfarrell#hashtidy#HashTidySortAlignKeyPairs () range
   call dnmfarrell#hashtidy#HashTidySortKeyPairs(a:firstline, a:lastline)
   call dnmfarrell#hashtidy#HashTidyAlignKeyPairs(a:firstline, a:lastline)
 endfunction
-
-command! -range HashTidySortRange call dnmfarrell#hashtidy#HashTidySortKeyPairs(<line1>,<line2>)
-command! -range HashTidyAlignRange call dnmfarrell#hashtidy#HashTidyAlignKeyPairs(<line1>,<line2>)
-command! -range HashTidySortAlignRange <line1>,<line2>call dnmfarrell#hashtidy#HashTidySortAlignKeyPairs()

--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -1,0 +1,10 @@
+" Vim filetype plugin file for HashTidy
+" Languages:          Perl, Raku
+" Project Repository: https://github.com/dnmfarrell/Hash-Tidy
+
+" Note: ignore b:did_ftplugin since our changes are in addition to changes
+"       other Perl or Raku plugins might make.
+
+command! -range HashTidySortRange call dnmfarrell#hashtidy#HashTidySortKeyPairs(<line1>,<line2>)
+command! -range HashTidyAlignRange call dnmfarrell#hashtidy#HashTidyAlignKeyPairs(<line1>,<line2>)
+command! -range HashTidySortAlignRange <line1>,<line2>call dnmfarrell#hashtidy#HashTidySortAlignKeyPairs()

--- a/ftplugin/perl6.vim
+++ b/ftplugin/perl6.vim
@@ -1,0 +1,1 @@
+perl.vim


### PR DESCRIPTION
No functionality changes (as far as I can tell!).  Closes #1.

Structural changes:
- Split `plugin/hash-tidy.vim` into `autoload` and `ftplugin` files
- Make the internal functions script-private (`s:`).

Documentation changes:
- Update README.md to reflect the new layout, and link to some "how-to-install-plugins" resources.
- Mention Raku, since it works fine for Raku as well!

Other changes:
- Add an [EditorConfig](https://editorconfig.org) file (full disclosure: I currently help maintain the EditorConfig vim plugin)
- Add a few more filetypes to .gitignore (notably `*.swp`)

(**edit** the force-push from 2a884f2 to ff89efe only changed the order of commits, not their contents.  Now the purely logistical commits are first.  Let me know if you prefer more or fewer commits.  For example, I could squash to one logistical commit, one refactoring commit, and one documentation commit.)